### PR TITLE
Bass4Py.bass.FX: remove the effect member of the class and replaced i…

### DIFF
--- a/Bass4Py/bass/effects/dx8/chorus.pyx
+++ b/Bass4Py/bass/effects/dx8/chorus.pyx
@@ -7,96 +7,98 @@ from ....bindings.bass cimport (
   DWORD)
 
 from ...fx cimport FX
-from cpython.mem cimport PyMem_Malloc
+
 
 cdef class Chorus(FX):
+  cdef BASS_DX8_CHORUS effect
+  cdef void* _get_effect(self) nogil except NULL: return <void*>&self.effect
 
   def __cinit__(Chorus self):
-    cdef BASS_DX8_CHORUS *effect
+
 
     self._type = _BASS_FX_DX8_CHORUS
 
-    effect = <BASS_DX8_CHORUS*>PyMem_Malloc(sizeof(BASS_DX8_CHORUS))
-    
-    if effect == NULL:
-      raise MemoryError()
-      
-    self._effect = effect
 
-    effect.fWetDryMix = 50.0
-    effect.fDepth = 10.0
-    effect.fFeedback = 25.0
-    effect.fFrequency = 1.1
-    effect.lWaveform = 1
-    effect.fDelay = 16.0
-    effect.lPhase = _BASS_DX8_PHASE_90
+    
+
+
+      
+
+
+    self.effect.fWetDryMix = 50.0
+    self.effect.fDepth = 10.0
+    self.effect.fFeedback = 25.0
+    self.effect.fFrequency = 1.1
+    self.effect.lWaveform = 1
+    self.effect.fDelay = 16.0
+    self.effect.lPhase = _BASS_DX8_PHASE_90
 
   property wet_dry_mix:
     def __get__(Chorus self):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
-      return effect.fWetDryMix
+
+      return self.effect.fWetDryMix
 
     def __set__(Chorus self, float value):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
+
       self._validate_range(value, 0.0, 100.0)
-      effect.fWetDryMix = value
+      self.effect.fWetDryMix = value
 
   property depth:
     def __get__(Chorus self):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
-      return effect.fDepth
+
+      return self.effect.fDepth
 
     def __set__(Chorus self, float value):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
+
       self._validate_range(value, 0.0, 100.0)
-      effect.fDepth = value
+      self.effect.fDepth = value
 
   property feedback:
     def __get__(Chorus self):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
-      return effect.fFeedback
+
+      return self.effect.fFeedback
 
     def __set__(Chorus self, float value):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
+
       self._validate_range(value, -99.0, 99.0)
-      effect.fFeedback = value
+      self.effect.fFeedback = value
 
   property frequency:
     def __get__(Chorus self):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
-      return effect.fFrequency
+
+      return self.effect.fFrequency
 
     def __set__(Chorus self, float value):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
+
       self._validate_range(value, 0.0, 10.0)
-      effect.fFrequency = value
+      self.effect.fFrequency = value
 
   property waveform:
     def __get__(Chorus self):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
-      return effect.lWaveform
+
+      return self.effect.lWaveform
 
     def __set__(Chorus self, DWORD value):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
+
       self._validate_range(value, 0, 1)
-      effect.lWaveform = value
+      self.effect.lWaveform = value
 
   property delay:
     def __get__(Chorus self):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
-      return effect.fDelay
+
+      return self.effect.fDelay
 
     def __set__(Chorus self, float value):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
+
       self._validate_range(value, 0, 20)
-      effect.fDelay = value
+      self.effect.fDelay = value
 
   property phase:
     def __get__(Chorus self):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
-      return effect.lPhase
+
+      return self.effect.lPhase
 
     def __set__(Chorus self, DWORD value):
-      cdef BASS_DX8_CHORUS *effect = <BASS_DX8_CHORUS*>(self._effect)
+
       self._validate_range(value, _BASS_DX8_PHASE_NEG_180, _BASS_DX8_PHASE_180)
-      effect.lPhase = value
+      self.effect.lPhase = value

--- a/Bass4Py/bass/effects/dx8/compressor.pyx
+++ b/Bass4Py/bass/effects/dx8/compressor.pyx
@@ -3,85 +3,88 @@ from ....bindings.bass cimport (
   _BASS_FX_DX8_COMPRESSOR)
 
 from ...fx cimport FX
-from cpython.mem cimport PyMem_Malloc
+
 
 cdef class Compressor(FX):
+  cdef BASS_DX8_COMPRESSOR effect
+  cdef void* _get_effect(self) nogil except NULL: return <void*>&self.effect
+
+
 
   def __cinit__(Compressor self):
-    cdef BASS_DX8_COMPRESSOR *effect
+
 
     self._type = _BASS_FX_DX8_COMPRESSOR
 
-    effect = <BASS_DX8_COMPRESSOR*>PyMem_Malloc(sizeof(BASS_DX8_COMPRESSOR))
-    
-    if effect == NULL:
-      raise MemoryError()
-      
-    self._effect = effect
 
-    effect.fGain = 0.0
-    effect.fAttack = 10.0
-    effect.fRelease = 200.0
-    effect.fThreshold = -20.0
-    effect.fRatio = 3.0
-    effect.fPredelay = 4.0
+    
+
+
+      
+
+
+    self.effect.fGain = 0.0
+    self.effect.fAttack = 10.0
+    self.effect.fRelease = 200.0
+    self.effect.fThreshold = -20.0
+    self.effect.fRatio = 3.0
+    self.effect.fPredelay = 4.0
 
   property gain:
     def __get__(Compressor self):
-      cdef BASS_DX8_COMPRESSOR *effect = <BASS_DX8_COMPRESSOR*>(self._effect)
-      return effect.fGain
+
+      return self.effect.fGain
 
     def __set__(Compressor self, float value):
-      cdef BASS_DX8_COMPRESSOR *effect = <BASS_DX8_COMPRESSOR*>(self._effect)
+
       self._validate_range(value, -60.0, 60.0)
-      effect.fGain = value
+      self.effect.fGain = value
 
   property attack:
     def __get__(Compressor self):
-      cdef BASS_DX8_COMPRESSOR *effect = <BASS_DX8_COMPRESSOR*>(self._effect)
-      return effect.fAttack
+
+      return self.effect.fAttack
 
     def __set__(Compressor self, float value):
-      cdef BASS_DX8_COMPRESSOR *effect = <BASS_DX8_COMPRESSOR*>(self._effect)
+
       self._validate_range(value, 0.01, 500.0)
-      effect.fAttack = value
+      self.effect.fAttack = value
 
   property release:
     def __get__(Compressor self):
-      cdef BASS_DX8_COMPRESSOR *effect = <BASS_DX8_COMPRESSOR*>(self._effect)
-      return effect.fRelease
+      return self.effect.fRelease
 
     def __set__(Compressor self, float value):
-      cdef BASS_DX8_COMPRESSOR *effect = <BASS_DX8_COMPRESSOR*>(self._effect)
+
       self._validate_range(value, 50.0, 3000.0)
-      effect.fRelease = value
+      self.effect.fRelease = value
 
   property threshold:
     def __get__(Compressor self):
-      cdef BASS_DX8_COMPRESSOR *effect = <BASS_DX8_COMPRESSOR*>(self._effect)
-      return effect.fThreshold
+
+      return self.effect.fThreshold
 
     def __set__(Compressor self, float value):
-      cdef BASS_DX8_COMPRESSOR *effect = <BASS_DX8_COMPRESSOR*>(self._effect)
+
       self._validate_range(value, -60.0, 0.0)
-      effect.fThreshold = value
+      self.effect.fThreshold = value
 
   property ratio:
     def __get__(Compressor self):
-      cdef BASS_DX8_COMPRESSOR *effect = <BASS_DX8_COMPRESSOR*>(self._effect)
-      return effect.fRatio
+
+      return self.effect.fRatio
 
     def __set__(Compressor self, float value):
-      cdef BASS_DX8_COMPRESSOR *effect = <BASS_DX8_COMPRESSOR*>(self._effect)
+
       self._validate_range(value, 1.0, 100.0)
-      effect.fRatio = value
+      self.effect.fRatio = value
 
   property predelay:
     def __get__(Compressor self):
-      cdef BASS_DX8_COMPRESSOR *effect = <BASS_DX8_COMPRESSOR*>(self._effect)
-      return effect.fPredelay
+
+      return self.effect.fPredelay
 
     def __set__(Compressor self, float value):
-      cdef BASS_DX8_COMPRESSOR *effect = <BASS_DX8_COMPRESSOR*>(self._effect)
+
       self._validate_range(value, 0.0, 4.0)
-      effect.fPredelay = value
+      self.effect.fPredelay = value

--- a/Bass4Py/bass/effects/dx8/distortion.pyx
+++ b/Bass4Py/bass/effects/dx8/distortion.pyx
@@ -3,74 +3,78 @@ from ....bindings.bass cimport (
   _BASS_FX_DX8_DISTORTION)
 
 from ...fx cimport FX
-from cpython.mem cimport PyMem_Malloc
+
 
 cdef class Distortion(FX):
+  cdef BASS_DX8_DISTORTION effect
+
+  cdef void* _get_effect(self) nogil except NULL: return <void*>&self.effect
+
 
   def __cinit__(Distortion self):
-    cdef BASS_DX8_DISTORTION *effect
+
 
     self._type = _BASS_FX_DX8_DISTORTION
 
-    effect = <BASS_DX8_DISTORTION*>PyMem_Malloc(sizeof(BASS_DX8_DISTORTION))
-    
-    if effect == NULL:
-      raise MemoryError()
-      
-    self._effect = effect
 
-    effect.fGain = -18.0
-    effect.fEdge = 15.0
-    effect.fPostEQCenterFrequency = 2400.0
-    effect.fPostEQBandwidth = 2400.0
-    effect.fPreLowpassCutoff = 8000.0
+    
+
+
+      
+
+
+    self.effect.fGain = -18.0
+    self.effect.fEdge = 15.0
+    self.effect.fPostEQCenterFrequency = 2400.0
+    self.effect.fPostEQBandwidth = 2400.0
+    self.effect.fPreLowpassCutoff = 8000.0
 
   property gain:
     def __get__(Distortion self):
-      cdef BASS_DX8_DISTORTION *effect = <BASS_DX8_DISTORTION*>(self._effect)
-      return effect.fGain
+
+      return self.effect.fGain
 
     def __set__(Distortion self, float value):
-      cdef BASS_DX8_DISTORTION *effect = <BASS_DX8_DISTORTION*>(self._effect)
+
       self._validate_range(value, -60.0, 0.0)
-      effect.fGain = value
+      self.effect.fGain = value
 
   property edge:
     def __get__(Distortion self):
-      cdef BASS_DX8_DISTORTION *effect = <BASS_DX8_DISTORTION*>(self._effect)
-      return effect.fEdge
+
+      return self.effect.fEdge
 
     def __set__(Distortion self, float value):
-      cdef BASS_DX8_DISTORTION *effect = <BASS_DX8_DISTORTION*>(self._effect)
+
       self._validate_range(value, 0.0, 100.0)
-      effect.fEdge = value
+      self.effect.fEdge = value
 
   property post_eq_center_frequency:
     def __get__(Distortion self):
-      cdef BASS_DX8_DISTORTION *effect = <BASS_DX8_DISTORTION*>(self._effect)
-      return effect.fPostEQCenterFrequency
+
+      return self.effect.fPostEQCenterFrequency
 
     def __set__(Distortion self, float value):
-      cdef BASS_DX8_DISTORTION *effect = <BASS_DX8_DISTORTION*>(self._effect)
+
       self._validate_range(value, 100.0, 8000.0)
-      effect.fPostEQCenterFrequency = value
+      self.effect.fPostEQCenterFrequency = value
 
   property post_eq_bandwidth:
     def __get__(Distortion self):
-      cdef BASS_DX8_DISTORTION *effect = <BASS_DX8_DISTORTION*>(self._effect)
-      return effect.fPostEQBandwidth
+
+      return self.effect.fPostEQBandwidth
 
     def __set__(Distortion self, float value):
-      cdef BASS_DX8_DISTORTION *effect = <BASS_DX8_DISTORTION*>(self._effect)
+
       self._validate_range(value, 100.0, 8000.0)
-      effect.fPostEQBandwidth = value
+      self.effect.fPostEQBandwidth = value
 
   property pre_lowpass_cutoff:
     def __get__(Distortion self):
-      cdef BASS_DX8_DISTORTION *effect = <BASS_DX8_DISTORTION*>(self._effect)
-      return effect.fPreLowpassCutoff
+
+      return self.effect.fPreLowpassCutoff
 
     def __set__(Distortion self, float value):
-      cdef BASS_DX8_DISTORTION *effect = <BASS_DX8_DISTORTION*>(self._effect)
+
       self._validate_range(value, 100.0, 8000.0)
-      effect.fPreLowpassCutoff = value
+      self.effect.fPreLowpassCutoff = value

--- a/Bass4Py/bass/effects/dx8/echo.pyx
+++ b/Bass4Py/bass/effects/dx8/echo.pyx
@@ -3,74 +3,72 @@ from ....bindings.bass cimport (
   _BASS_FX_DX8_ECHO)
 
 from ...fx cimport FX
-from cpython.mem cimport PyMem_Malloc
+
 
 cdef class Echo(FX):
+  cdef BASS_DX8_ECHO effect
+  cdef void* _get_effect(self) nogil except NULL: return <void*>&self.effect
 
   def __cinit__(Echo self):
-    cdef BASS_DX8_ECHO *effect
+
 
     self._type = _BASS_FX_DX8_ECHO
 
-    effect = <BASS_DX8_ECHO*>PyMem_Malloc(sizeof(BASS_DX8_ECHO))
-    
-    if effect == NULL:
-      raise MemoryError()
-      
-    self._effect = effect
 
-    effect.fWetDryMix = 50.0
-    effect.fFeedback = 50.0
-    effect.fLeftDelay = 500.0
-    effect.fRightDelay = 500.0
-    effect.lPanDelay = False
+
+
+    self.effect.fWetDryMix = 50.0
+    self.effect.fFeedback = 50.0
+    self.effect.fLeftDelay = 500.0
+    self.effect.fRightDelay = 500.0
+    self.effect.lPanDelay = False
 
   property wet_dry_mix:
     def __get__(Echo self):
-      cdef BASS_DX8_ECHO *effect = <BASS_DX8_ECHO*>(self._effect)
-      return effect.fWetDryMix
+
+      return self.effect.fWetDryMix
 
     def __set__(Echo self, float value):
-      cdef BASS_DX8_ECHO *effect = <BASS_DX8_ECHO*>(self._effect)
+
       self._validate_range(value, 0.0, 100.0)
-      effect.fWetDryMix = value
+      self.effect.fWetDryMix = value
 
   property feedback:
     def __get__(Echo self):
-      cdef BASS_DX8_ECHO *effect = <BASS_DX8_ECHO*>(self._effect)
-      return effect.fFeedback
+
+      return self.effect.fFeedback
 
     def __set__(Echo self, float value):
-      cdef BASS_DX8_ECHO *effect = <BASS_DX8_ECHO*>(self._effect)
+
       self._validate_range(value, 0.0, 100.0)
-      effect.fFeedback = value
+      self.effect.fFeedback = value
 
   property left_delay:
     def __get__(Echo self):
-      cdef BASS_DX8_ECHO *effect = <BASS_DX8_ECHO*>(self._effect)
-      return effect.fLeftDelay
+
+      return self.effect.fLeftDelay
 
     def __set__(Echo self,float value):
-      cdef BASS_DX8_ECHO *effect = <BASS_DX8_ECHO*>(self._effect)
+
       self._validate_range(value, 1.0, 2000.0)
-      effect.fLeftDelay = value
+      self.effect.fLeftDelay = value
 
   property right_delay:
     def __get__(Echo self):
-      cdef BASS_DX8_ECHO *effect = <BASS_DX8_ECHO*>(self._effect)
-      return effect.fRightDelay
+
+      return self.effect.fRightDelay
 
     def __set__(Echo self, float value):
-      cdef BASS_DX8_ECHO *effect = <BASS_DX8_ECHO*>(self._effect)
+
       self._validate_range(value, 1.0, 2000.0)
-      effect.fRightDelay = value
+      self.effect.fRightDelay = value
 
   property pan_delay:
     def __get__(Echo self):
-      cdef BASS_DX8_ECHO *effect = <BASS_DX8_ECHO*>(self._effect)
-      return effect.lPanDelay
+
+      return self.effect.lPanDelay
 
     def __set__(Echo self, bint value):
-      cdef BASS_DX8_ECHO *effect = <BASS_DX8_ECHO*>(self._effect)
+
       self._validate_range(value, False, True)
-      effect.lPanDelay = value
+      self.effect.lPanDelay = value

--- a/Bass4Py/bass/effects/dx8/flanger.pyx
+++ b/Bass4Py/bass/effects/dx8/flanger.pyx
@@ -7,96 +7,99 @@ from ....bindings.bass cimport (
   DWORD)
 
 from ...fx cimport FX
-from cpython.mem cimport PyMem_Malloc
+
 
 cdef class Flanger(FX):
+  cdef BASS_DX8_FLANGER effect
+
+  cdef void* _get_effect(self) nogil except NULL: return <void*>&self.effect
 
   def __cinit__(Flanger self):
-    cdef BASS_DX8_FLANGER *effect
+
 
     self._type = _BASS_FX_DX8_FLANGER
 
-    effect = <BASS_DX8_FLANGER*>PyMem_Malloc(sizeof(BASS_DX8_FLANGER))
-    
-    if effect == NULL:
-      raise MemoryError()
-      
-    self._effect = effect
 
-    effect.fWetDryMix = 50.0
-    effect.fDepth = 100.0
-    effect.fFeedback = -50.0
-    effect.fFrequency = 0.25
-    effect.lWaveform = 1
-    effect.fDelay = 2.0
-    effect.lPhase = _BASS_DX8_PHASE_ZERO
+
+
+
+      
+
+
+    self.effect.fWetDryMix = 50.0
+    self.effect.fDepth = 100.0
+    self.effect.fFeedback = -50.0
+    self.effect.fFrequency = 0.25
+    self.effect.lWaveform = 1
+    self.effect.fDelay = 2.0
+    self.effect.lPhase = _BASS_DX8_PHASE_ZERO
 
   property wet_dry_mix:
     def __get__(Flanger self):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
-      return effect.fWetDryMix
+
+      return self.effect.fWetDryMix
 
     def __set__(Flanger self, float value):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
+
       self._validate_range(value, 0.0, 100.0)
-      effect.fWetDryMix = value
+      self.effect.fWetDryMix = value
 
   property depth:
     def __get__(Flanger self):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
-      return effect.fDepth
+
+      return self.effect.fDepth
 
     def __set__(Flanger self,float value):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
+
       self._validate_range(value, 0.0, 100.0)
-      effect.fDepth = value
+      self.effect.fDepth = value
 
   property feedback:
     def __get__(Flanger self):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
-      return effect.fFeedback
+
+      return self.effect.fFeedback
 
     def __set__(Flanger self, float value):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
+
       self._validate_range(value, -99.0, 99.0)
-      effect.fFeedback = value
+      self.effect.fFeedback = value
 
   property frequency:
     def __get__(Flanger self):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
-      return effect.fFrequency
+
+      return self.effect.fFrequency
 
     def __set__(Flanger self,float value):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
+
       self._validate_range(value, 0.0, 10.0)
-      effect.fFrequency = value
+      self.effect.fFrequency = value
 
   property waveform:
     def __get__(Flanger self):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
-      return effect.lWaveform
+
+      return self.effect.lWaveform
 
     def __set__(Flanger self, DWORD value):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
+
       self._validate_range(value, 0, 1)
-      effect.lWaveform = value
+      self.effect.lWaveform = value
 
   property delay:
     def __get__(Flanger self):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
-      return effect.fDelay
+
+      return self.effect.fDelay
 
     def __set__(Flanger self, float value):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
+
       self._validate_range(value, 0.0, 4.0)
-      effect.fDelay = value
+      self.effect.fDelay = value
 
   property phase:
     def __get__(Flanger self):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
-      return effect.lPhase
+
+      return self.effect.lPhase
 
     def __set__(Flanger self, DWORD value):
-      cdef BASS_DX8_FLANGER *effect = <BASS_DX8_FLANGER*>(self._effect)
+
       self._validate_range(value, _BASS_DX8_PHASE_NEG_180, _BASS_DX8_PHASE_180)
-      effect.lPhase = value
+      self.effect.lPhase = value

--- a/Bass4Py/bass/effects/dx8/gargle.pyx
+++ b/Bass4Py/bass/effects/dx8/gargle.pyx
@@ -4,41 +4,44 @@ from ....bindings.bass cimport (
   DWORD)
 
 from ...fx cimport FX
-from cpython.mem cimport PyMem_Malloc
+
 
 cdef class Gargle(FX):
+  cdef BASS_DX8_GARGLE effect
+
+  cdef void* _get_effect(self) nogil except NULL: return <void*>&self.effect
 
   def __cinit__(Gargle self):
-    cdef BASS_DX8_GARGLE *effect
+
 
     self._type = _BASS_FX_DX8_GARGLE
 
-    effect = <BASS_DX8_GARGLE*>PyMem_Malloc(sizeof(BASS_DX8_GARGLE))
-    
-    if effect == NULL:
-      raise MemoryError()
-      
-    self._effect = effect
 
-    effect.dwRateHz = 20
-    effect.dwWaveShape = 0
+    
+
+
+      
+
+
+    self.effect.dwRateHz = 20
+    self.effect.dwWaveShape = 0
 
   property rate_hz:
     def __get__(Gargle self):
-      cdef BASS_DX8_GARGLE *effect = <BASS_DX8_GARGLE*>(self._effect)
-      return effect.dwRateHz
+
+      return self.effect.dwRateHz
 
     def __set__(Gargle self, DWORD value):
-      cdef BASS_DX8_GARGLE *effect = <BASS_DX8_GARGLE*>(self._effect)
+
       self._validate_range(value, 1, 1000)
-      effect.dwRateHz = value
+      self.effect.dwRateHz = value
 
   property wave_shape:
     def __get__(Gargle self):
-      cdef BASS_DX8_GARGLE *effect = <BASS_DX8_GARGLE*>(self._effect)
-      return effect.dwWaveShape
+
+      return self.effect.dwWaveShape
 
     def __set__(Gargle self, DWORD value):
-      cdef BASS_DX8_GARGLE *effect = <BASS_DX8_GARGLE*>(self._effect)
+
       self._validate_range(value, 0, 1)
-      effect.dwWaveShape = value
+      self.effect.dwWaveShape = value

--- a/Bass4Py/bass/effects/dx8/i3dl2reverb.pyx
+++ b/Bass4Py/bass/effects/dx8/i3dl2reverb.pyx
@@ -7,148 +7,154 @@ from ...fx cimport FX
 from cpython.mem cimport PyMem_Malloc
 
 cdef class I3DL2Reverb(FX):
+  cdef BASS_DX8_I3DL2REVERB effect
+  cdef void* _get_effect(self) nogil except NULL: return <void*>&self.effect
+
+
+
+
 
   def __cinit__(I3DL2Reverb self):
-    cdef BASS_DX8_I3DL2REVERB *effect
+
 
     self._type = _BASS_FX_DX8_I3DL2REVERB
 
-    effect = <BASS_DX8_I3DL2REVERB*>PyMem_Malloc(sizeof(BASS_DX8_I3DL2REVERB))
-    
-    if effect == NULL:
-      raise MemoryError()
-      
-    self._effect = effect
 
-    effect.lRoom = -1000
-    effect.lRoomHF = -100
-    effect.flRoomRolloffFactor = 0.0
-    effect.flDecayTime = 1.49
-    effect.flDecayHFRatio = 0.83
-    effect.lReflections = -2602
-    effect.flReflectionsDelay = 0.007
-    effect.lReverb = 200
-    effect.flReverbDelay = 0.011
-    effect.flDiffusion = 100.0
-    effect.flDensity = 100.0
-    effect.flHFReference = 5000.0
+    
+
+
+      
+
+
+    self.effect.lRoom = -1000
+    self.effect.lRoomHF = -100
+    self.effect.flRoomRolloffFactor = 0.0
+    self.effect.flDecayTime = 1.49
+    self.effect.flDecayHFRatio = 0.83
+    self.effect.lReflections = -2602
+    self.effect.flReflectionsDelay = 0.007
+    self.effect.lReverb = 200
+    self.effect.flReverbDelay = 0.011
+    self.effect.flDiffusion = 100.0
+    self.effect.flDensity = 100.0
+    self.effect.flHFReference = 5000.0
 
   property room:
     def __get__(I3DL2Reverb self):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
-      return effect.lRoom
+
+      return self.effect.lRoom
 
     def __set__(I3DL2Reverb self, int value):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
+
       self._validate_range(value, -10000, 0)
-      effect.lRoom = value
+      self.effect.lRoom = value
 
   property room_hf:
     def __get__(I3DL2Reverb self):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
-      return effect.lRoomHF
+
+      return self.effect.lRoomHF
 
     def __set__(I3DL2Reverb self, int value):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
+
       self._validate_range(value, -10000, 0)
-      effect.lRoomHF = value
+      self.effect.lRoomHF = value
 
   property room_rolloff_factor:
     def __get__(I3DL2Reverb self):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
-      return effect.flRoomRolloffFactor
+
+      return self.effect.flRoomRolloffFactor
 
     def __set__(I3DL2Reverb self, float value):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
+
       self._validate_range(value, 0.0, 10.0)
-      effect.flRoomRolloffFactor = value
+      self.effect.flRoomRolloffFactor = value
 
   property decay_time:
     def __get__(I3DL2Reverb self):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
-      return effect.flDecayTime
+
+      return self.effect.flDecayTime
 
     def __set__(I3DL2Reverb self, float value):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
+
       self._validate_range(value, 0.1, 20.0)
-      effect.flDecayTime = value
+      self.effect.flDecayTime = value
 
   property decay_hf_ratio:
     def __get__(I3DL2Reverb self):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
-      return effect.flDecayHFRatio
+
+      return self.effect.flDecayHFRatio
 
     def __set__(I3DL2Reverb self, float value):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
+
       self._validate_range(value, 0.1, 2.0)
-      effect.flDecayHFRatio = value
+      self.effect.flDecayHFRatio = value
 
   property reflections:
     def __get__(I3DL2Reverb self):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
-      return effect.lReflections
+
+      return self.effect.lReflections
 
     def __set__(I3DL2Reverb self, int value):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
+
       self._validate_range(value, -10000, 1000)
-      effect.lReflections = value
+      self.effect.lReflections = value
 
   property reeflections_delay:
     def __get__(I3DL2Reverb self):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
-      return effect.flReflectionsDelay
+
+      return self.effect.flReflectionsDelay
 
     def __set__(I3DL2Reverb self, float value):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
+
       self._validate_range(value, 0.0, 0.3)
-      effect.flReflectionsDelay = value
+      self.effect.flReflectionsDelay = value
 
   property reverb:
     def __get__(I3DL2Reverb self):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
-      return effect.lReverb
+
+      return self.effect.lReverb
 
     def __set__(I3DL2Reverb self, int value):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
+
       self._validate_range(value, -10000, 2000)
-      effect.lReverb = value
+      self.effect.lReverb = value
 
   property reverb_delay:
     def __get__(I3DL2Reverb self):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
-      return effect.flReverbDelay
+
+      return self.effect.flReverbDelay
 
     def __set__(I3DL2Reverb self, float value):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
+
       self._validate_range(value, 0.0, 0.1)
-      effect.flReverbDelay = value
+      self.effect.flReverbDelay = value
 
   property diffusion:
     def __get__(I3DL2Reverb self):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
-      return effect.flDiffusion
+
+      return self.effect.flDiffusion
 
     def __set__(I3DL2Reverb self, float value):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
+
       self._validate_range(value, 0.0, 100.0)
-      effect.flDiffusion = value
+      self.effect.flDiffusion = value
 
   property density:
     def __get__(I3DL2Reverb self):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
-      return effect.flDensity
+
+      return self.effect.flDensity
 
     def __set__(I3DL2Reverb self, float value):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
+
       self._validate_range(value, 0.0, 100.0)
-      effect.flDensity = value
+      self.effect.flDensity = value
 
   property hf_reference:
     def __get__(I3DL2Reverb self):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
-      return effect.flHFReference
+
+      return self.effect.flHFReference
 
     def __set__(I3DL2Reverb self, float value):
-      cdef BASS_DX8_I3DL2REVERB *effect = <BASS_DX8_I3DL2REVERB*>(self._effect)
+
       self._validate_range(value, 20.0, 20000.0)
-      effect.flHFReference = value
+      self.effect.flHFReference = value

--- a/Bass4Py/bass/effects/dx8/parameq.pyx
+++ b/Bass4Py/bass/effects/dx8/parameq.pyx
@@ -9,28 +9,32 @@ from ....bindings.bass cimport (
 from ...channel cimport Channel
 from ...fx cimport FX
 
-from cpython.mem cimport PyMem_Malloc
+
 
 cdef class Parameq(FX):
+  cdef BASS_DX8_PARAMEQ effect
+
+  cdef void* _get_effect(self) nogil except NULL: return <void*>&self.effect
+
 
   def __cinit__(Parameq self):
-    cdef BASS_DX8_PARAMEQ *effect
+
 
     self._type = _BASS_FX_DX8_PARAMEQ
 
-    effect = <BASS_DX8_PARAMEQ*>PyMem_Malloc(sizeof(BASS_DX8_PARAMEQ))
-    
-    if effect == NULL:
-      raise MemoryError()
-      
-    self._effect = effect
 
-    effect.fCenter = 0.0
-    effect.fBandwidth = 12.0
-    effect.fGain = 0.0
+    
+
+
+      
+
+
+    self.effect.fCenter = 0.0
+    self.effect.fBandwidth = 12.0
+    self.effect.fGain = 0.0
 
   cpdef set(Parameq self, Channel chan):
-    cdef BASS_DX8_PARAMEQ *effect = <BASS_DX8_PARAMEQ*>(self._effect)
+    cdef BASS_DX8_PARAMEQ *effect = &self.effect
     cdef BASS_DX8_PARAMEQ temp
 
     self._set_fx(chan)
@@ -47,11 +51,11 @@ cdef class Parameq(FX):
 
   property center:
     def __get__(Parameq self):
-      cdef BASS_DX8_PARAMEQ *effect = <BASS_DX8_PARAMEQ*>(self._effect)
-      return effect.fCenter
+
+      return self.effect.fCenter
 
     def __set__(Parameq self, float value):
-      cdef BASS_DX8_PARAMEQ *effect = <BASS_DX8_PARAMEQ*>(self._effect)
+      cdef BASS_DX8_PARAMEQ *effect = &self.effect
       cdef BASS_CHANNELINFO info
 
       if self.channel == None:
@@ -74,20 +78,20 @@ cdef class Parameq(FX):
 
   property bandwidth:
     def __get__(Parameq self):
-      cdef BASS_DX8_PARAMEQ *effect = <BASS_DX8_PARAMEQ*>(self._effect)
-      return effect.fBandwidth
+
+      return self.effect.fBandwidth
 
     def __set__(Parameq self, float value):
-      cdef BASS_DX8_PARAMEQ *effect = <BASS_DX8_PARAMEQ*>(self._effect)
+
       self._validate_range(value, 1.0, 36.0)
-      effect.fBandwidth = value
+      self.effect.fBandwidth = value
 
   property gain:
     def __get__(Parameq self):
-      cdef BASS_DX8_PARAMEQ *effect = <BASS_DX8_PARAMEQ*>(self._effect)
-      return effect.fGain
+
+      return self.effect.fGain
 
     def __set__(Parameq self, float value):
-      cdef BASS_DX8_PARAMEQ *effect = <BASS_DX8_PARAMEQ*>(self._effect)
+
       self._validate_range(value, -15.0, 15.0)
-      effect.fGain = value
+      self.effect.fGain = value

--- a/Bass4Py/bass/effects/dx8/reverb.pyx
+++ b/Bass4Py/bass/effects/dx8/reverb.pyx
@@ -7,60 +7,64 @@ from ...fx cimport FX
 from cpython.mem cimport PyMem_Malloc
 
 cdef class Reverb(FX):
+  cdef BASS_DX8_REVERB *effect
+
+
+  cdef void* _get_effect(self) nogil except NULL: return <void*>&self.effect
 
   def __cinit__(Reverb self):
-    cdef BASS_DX8_REVERB *effect
+
 
     self._type = _BASS_FX_DX8_REVERB
 
-    effect = <BASS_DX8_REVERB*>PyMem_Malloc(sizeof(BASS_DX8_REVERB))
-    
-    if effect == NULL:
-      raise MemoryError()
-      
-    self._effect = effect
 
-    effect.fInGain = 0.0
-    effect.fReverbMix = 0.0
-    effect.fReverbTime = 1000.0
-    effect.fHighFreqRTRatio = 0.001
+    
+
+
+      
+
+
+    self.effect.fInGain = 0.0
+    self.effect.fReverbMix = 0.0
+    self.effect.fReverbTime = 1000.0
+    self.effect.fHighFreqRTRatio = 0.001
 
   property in_gain:
     def __get__(Reverb self):
-      cdef BASS_DX8_REVERB *effect = <BASS_DX8_REVERB*>(self._effect)
-      return effect.fInGain
+
+      return self.effect.fInGain
 
     def __set__(Reverb self, float value):
-      cdef BASS_DX8_REVERB *effect = <BASS_DX8_REVERB*>(self._effect)
+
       self._validate_range(value, -96.0, 0.0)
-      effect.fInGain = value
+      self.effect.fInGain = value
 
   property reverb_mix:
     def __get__(Reverb self):
-      cdef BASS_DX8_REVERB *effect = <BASS_DX8_REVERB*>(self._effect)
-      return effect.fReverbMix
+
+      return self.effect.fReverbMix
 
     def __set__(Reverb self, float value):
-      cdef BASS_DX8_REVERB *effect = <BASS_DX8_REVERB*>(self._effect)
+
       self._validate_range(value, -96.0, 0.0)
-      effect.fReverbMix = value
+      self.effect.fReverbMix = value
 
   property reverb_time:
     def __get__(Reverb self):
-      cdef BASS_DX8_REVERB *effect = <BASS_DX8_REVERB*>(self._effect)
-      return effect.fReverbTime
+
+      return self.effect.fReverbTime
 
     def __set__(Reverb self, float value):
-      cdef BASS_DX8_REVERB *effect = <BASS_DX8_REVERB*>(self._effect)
+
       self._validate_range(value, 0.001, 3000.0)
-      effect.fReverbTime = value
+      self.effect.fReverbTime = value
 
   property high_freq_rt_ratio:
     def __get__(Reverb self):
-      cdef BASS_DX8_REVERB *effect = <BASS_DX8_REVERB*>(self._effect)
-      return effect.fHighFreqRTRatio
+
+      return self.effect.fHighFreqRTRatio
 
     def __set__(Reverb self, float value):
-      cdef BASS_DX8_REVERB *effect = <BASS_DX8_REVERB*>(self._effect)
+
       self._validate_range(value, 0.01, 0.999)
-      effect.fHighFreqRTRatio = value
+      self.effect.fHighFreqRTRatio = value

--- a/Bass4Py/bass/effects/volume.pyx
+++ b/Bass4Py/bass/effects/volume.pyx
@@ -8,71 +8,68 @@ from ...exceptions import BassOutOfRangeError
 from cpython.mem cimport PyMem_Malloc
 
 cdef class Volume(FX):
+  cdef BASS_FX_VOLUME_PARAM effect
+  cdef void* _get_effect(self) nogil except NULL: return <void*>&self.effect
+
 
   def __cinit__(Volume self):
-    cdef BASS_FX_VOLUME_PARAM *effect
 
     self._type = _BASS_FX_VOLUME
 
-    effect = <BASS_FX_VOLUME_PARAM*>PyMem_Malloc(sizeof(BASS_FX_VOLUME_PARAM))
-    
-    if effect == NULL:
-      raise MemoryError()
-      
-    self._effect = effect
 
-    effect.fTarget = 1.0
-    effect.fCurrent = 1.0
-    effect.fTime = 0.0
-    effect.lCurve = 0
+
+    self.effect.fTarget = 1.0
+    self.effect.fCurrent = 1.0
+    self.effect.fTime = 0.0
+    self.effect.lCurve = 0
 
   property target:
     def __get__(Volume self):
-      cdef BASS_FX_VOLUME_PARAM *effect = <BASS_FX_VOLUME_PARAM*>(self._effect)
-      return effect.fTarget
+
+      return self.effect.fTarget
 
     def __set__(Volume self, float value):
-      cdef BASS_FX_VOLUME_PARAM *effect = <BASS_FX_VOLUME_PARAM*>(self._effect)
+
 
       if value < 0.0:
         raise BassOutOfRangeError("FX parameter value {0} may not be less than 0".format(value))
 
-      effect.fTarget = value
+      self.effect.fTarget = value
 
   property current:
     def __get__(Volume self):
-      cdef BASS_FX_VOLUME_PARAM *effect = <BASS_FX_VOLUME_PARAM*>(self._effect)
-      return effect.fCurrent
+
+      return self.effect.fCurrent
 
     def __set__(Volume self, float value):
-      cdef BASS_FX_VOLUME_PARAM *effect = <BASS_FX_VOLUME_PARAM*>(self._effect)
+
 
       if value < -1.0:
         raise BassOutOfRangeError("FX parameter value {0} may not be less than -1".format(value))
 
-      effect.fCurrent = value
+      self.effect.fCurrent = value
 
   property time:
     def __get__(Volume self):
-      cdef BASS_FX_VOLUME_PARAM *effect = <BASS_FX_VOLUME_PARAM*>(self._effect)
-      return effect.fTime
+
+      return self.effect.fTime
 
     def __set__(Volume self, float value):
-      cdef BASS_FX_VOLUME_PARAM *effect = <BASS_FX_VOLUME_PARAM*>(self._effect)
+
 
       if value < 0.0:
         raise BassOutOfRangeError("FX parameter value {0} may not be less than 0".format(value))
 
-      effect.fTime = value
+      self.effect.fTime = value
 
   property curve:
     def __get__(Volume self):
-      cdef BASS_FX_VOLUME_PARAM *effect = <BASS_FX_VOLUME_PARAM*>(self._effect)
-      return effect.lCurve
+
+      return self.effect.lCurve
 
     def __set__(Volume self, DWORD value):
-      cdef BASS_FX_VOLUME_PARAM *effect = <BASS_FX_VOLUME_PARAM*>(self._effect)
+
 
       self._validate_range(value, 0.0, 1.0)
 
-      effect.lCurve = value
+      self.effect.lCurve = value

--- a/Bass4Py/bass/fx.pxd
+++ b/Bass4Py/bass/fx.pxd
@@ -16,7 +16,9 @@ cdef class FX(Evaluable):
   cdef HFX _fx
   cdef DWORD _type
   cdef int _priority
-  cdef void *_effect
+
+
+  cdef void* _get_effect(self) nogil except NULL
 
   cpdef remove(FX self)
   cpdef reset(FX self)


### PR DESCRIPTION
…t with the _get_effect function which returns a pointer to the effect parameters. All BASS effects now no longer use PyMem_Malloc to allocate the effect args, instead they store the BASS effect params struct inline and override the _get_effect method to return a pointer to that struct. This change makes the code smallerr and nicer. In the future I'd like to avoid manually initializing the effect parameters and make BASS do it for us. Might require preventing users from accessing effect attributes until this FX is attached to a channel though.