### PR TITLE
Setup: set the auto_pickle Cython directive to True

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,7 @@ if USE_CYTHON:
     gdb_debug = DEBUG_MODE,
     compiler_directives = {
       'embedsignature': True,
+      "auto_pickle": False, # you can't pickle BASS channels, as they handles are managed by BASS
       'language_level': 3,
       'linetrace': True if DEBUG_MODE else False,
     }


### PR DESCRIPTION
Prevents Cython from autogenerating pickle and unpickle methods for BASS objects because they don't work anyway. BASS objects cannot be pickled because they only contain BASS-managed handles.

Also reduces binary size somewhat