### PR TITLE
Tags and tags bindings: replace most uses of char* with const char* i…

### DIFF
--- a/Bass4Py/bindings/tags.pxd
+++ b/Bass4Py/bindings/tags.pxd
@@ -4,7 +4,7 @@ cdef extern from "tags.h" nogil:
 
   DWORD TAGS_GetVersion()
   bint TAGS_SetUTF8(bint)
-  char *TAGS_Read(DWORD, char *)
-  char *TAGS_ReadEx(DWORD, char *fmt, DWORD, int)
-  char *TAGS_GetLastErrorDesc()
+  const char *TAGS_Read(DWORD, char *)
+  const char *TAGS_ReadEx(DWORD, const char *fmt, DWORD, int)
+  const char *TAGS_GetLastErrorDesc()
 

--- a/Bass4Py/tags/tags.pyx
+++ b/Bass4Py/tags/tags.pyx
@@ -44,7 +44,7 @@ cdef class Tags:
   cpdef read(Tags self, object fmt = None, DWORD tagtype = -1):
 
     cdef const unsigned char[:] c_fmt
-    cdef char *res
+    cdef const char *res
 
     if fmt is not None:
 
@@ -72,4 +72,4 @@ cdef class Tags:
   
   property error:
     def __get__(Tags self):
-      return (<char*>TAGS_GetLastErrorDesc()).decode('utf-8')
+      return (<const char*>TAGS_GetLastErrorDesc()).decode('utf-8')


### PR DESCRIPTION
…n order to shut up MSVC warnings.