### PR TITLE
Optimize Stream.create_stream_from_file_obj by using file.readinto() …

### DIFF
--- a/Bass4Py/bass/stream.pyx
+++ b/Bass4Py/bass/stream.pyx
@@ -1,5 +1,4 @@
 from libc.string cimport memmove
-
 from ..bindings.bass cimport (
   _BASS_ATTRIB_BITRATE,
   _BASS_ATTRIB_NET_RESUME,
@@ -97,18 +96,12 @@ cdef QWORD __stdcall CFILELENPROC_STD(void *user) with gil:
 
 cdef DWORD CFILEREADPROC(void *buffer, DWORD length, void *user) with gil:
   cdef Stream strm = <Stream?>user
-  cdef bytes data
   cdef DWORD blen
-
+  cdef unsigned char[:] buffer_memoryview = <unsigned char[:length]>buffer # make memoryview, using buffer as the memory
   try:
-    data = strm._file.read(length)
-    blen = len(data)
+    blen = strm._file.readinto(buffer_memoryview) # read data directly from file into the buffer
 
-    if blen > length:
-      data = data[:length]
-      blen = length
-    
-    memmove(buffer, <char *>data, blen)
+
     return blen
   except Exception:
     warnings.warn(traceback.format_exc(), RuntimeWarning)

--- a/Bass4Py/bass/stream.pyx
+++ b/Bass4Py/bass/stream.pyx
@@ -102,7 +102,7 @@ cdef DWORD CFILEREADPROC(void *buffer, DWORD length, void *user) with gil:
   try:
     if hasattr(strm.file, "readinto"): blen = strm._file.readinto(buffer_memoryview) # read data directly from file into the buffer
     elif hasattr(strm.file, "read"):
-      bytes_memoryview = strm.file.read(len)
+      bytes_memoryview = strm.file.read(length)
       len = bytes_memoryview.shape[0] # we might not've gotten as much data as requested
       buffer_memoryview[:len] = bytes_memoryview[:len] # let Cython copy the data for us
     return blen

--- a/Bass4Py/bass/stream.pyx
+++ b/Bass4Py/bass/stream.pyx
@@ -100,9 +100,9 @@ cdef DWORD CFILEREADPROC(void *buffer, DWORD length, void *user) with gil:
   cdef unsigned char[:] buffer_memoryview = <unsigned char[:length]>buffer # make memoryview, using buffer as the memory
   cdef const unsigned char[:] bytes_memoryview # if readinto() is not available, we'll put the result of read() in this variable and copy the data
   try:
-    if hasattr(strm.file, "readinto"): blen = strm._file.readinto(buffer_memoryview) # read data directly from file into the buffer
-    elif hasattr(strm.file, "read"):
-      bytes_memoryview = strm.file.read(length)
+    if hasattr(strm._file, "readinto"): blen = strm._file.readinto(buffer_memoryview) # read data directly from file into the buffer
+    elif hasattr(strm._file, "read"):
+      bytes_memoryview = strm._file.read(length)
       len = bytes_memoryview.shape[0] # we might not've gotten as much data as requested
       buffer_memoryview[:len] = bytes_memoryview[:len] # let Cython copy the data for us
     return blen


### PR DESCRIPTION
…to copy data straight into the callback-provided output buffer without any kind of allocation.